### PR TITLE
README: replace deprecation warning with contributing notes

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -1,16 +1,8 @@
-# :warning: DEPRECATED
-
-This repository is no longer maintained. You can still use a REST client like
-[Requests](https://pypi.org/project/requests/) or other third-party Python
-library to access the [Discogs REST API](https://www.discogs.com/developers).
-
----
----
----
-
 # Discogs API Client
 
-This is the official Discogs API client for Python. It enables you to query the Discogs database for information on artists, releases, labels, users, Marketplace listings, and more. It also supports OAuth 1.0a authorization, which allows you to change user data such as profile information, collections and wantlists, inventory, and orders.
+This is an active fork of the official Discogs API client for Python, which was deprecated by discogs.com as of June 2020. We think it is a very useful Python module and decided to continue maintaining it. If you'd like to contribute your code or ideas into the module, you are very welcome to file a pull-request as described [here](#contributing) or open an [issue](https://github.com/joalla/discogs_client/issues) and tell us what you think.
+
+The Discogs API client enables you to query the Discogs database for information on artists, releases, labels, users, Marketplace listings, and more. It also supports OAuth 1.0a authorization, which allows you to change user data such as profile information, collections and wantlists, inventory, and orders.
 
 [![Build Status](https://travis-ci.org/discogs/discogs_client.png?branch=master)](https://travis-ci.org/discogs/discogs_client)
 [![Coverage Status](https://coveralls.io/repos/discogs/discogs_client/badge.png)](https://coveralls.io/r/discogs/discogs_client)


### PR DESCRIPTION
I left the coverage and travis ci links for now, they are still pointing to discogs accounts. I suggest we fix this in another PR when we have our own.