### PR TITLE
README: refine introductional text

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -1,8 +1,10 @@
-# Discogs API Client
+# python3-discogs-client
 
-This is an active fork of the official Discogs API client for Python, which was deprecated by discogs.com as of June 2020. We think it is a very useful Python module and decided to continue maintaining it. If you'd like to contribute your code or ideas into the module, you are very welcome to file a pull-request as described [here](#contributing) or open an [issue](https://github.com/joalla/discogs_client/issues) and tell us what you think.
+This is an active fork of the official "Discogs API client for Python", which was deprecated by discogs.com as of June 2020. We think it is a very useful Python module and decided to continue maintaining it. If you'd like to contribute your code, you are very welcome to submit a pull-request as described [here](#contributing).
 
-The Discogs API client enables you to query the Discogs database for information on artists, releases, labels, users, Marketplace listings, and more. It also supports OAuth 1.0a authorization, which allows you to change user data such as profile information, collections and wantlists, inventory, and orders.
+python3-discogs-client enables you to query the Discogs database (discogs.com) through its REST-API for information on artists, releases, labels, users, Marketplace listings, and more. It also supports OAuth 1.0a authorization, which allows you to change user data such as profile information, collections and wantlists, inventory, and orders.
+
+Find usage information on this README page or search and ask in the API section of the Discogs developer forum at https://www.discogs.com/forum/topic/1082.
 
 [![Build Status](https://travis-ci.org/discogs/discogs_client.png?branch=master)](https://travis-ci.org/discogs/discogs_client)
 [![Coverage Status](https://coveralls.io/repos/discogs/discogs_client/badge.png)](https://coveralls.io/r/discogs/discogs_client)


### PR DESCRIPTION
Hi,
* I removed the issue link - it redirects to pull-request page. Obviously our repo doesn't support issues - I guess that's because we are a fork of discogs_client.
* headline change to python3-discogs-client, to represent our upstream name more prominently.
* add notes on documentation - This README currently is all we got - no issues possible, hence we point to the API forum.