### PR TITLE
Updated README to reflect new pypi package name

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -14,7 +14,7 @@ Find usage information on this README page or search and ask in the API section 
 Install [the client from PyPI](https://pypi.org/project/python3-discogs-client/) using your favorite package manager.
 
 ```sh
-$ pip install discogs_client
+$ pip install python3-discogs-client
 ```
 
 ## Quickstart


### PR DESCRIPTION
The `README` had out of date instructions to install the original package, this PR updates it so it points to this repos package