### PR TITLE
Change Package Development status

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
         author_email='jt@peek-a-boo.at',
         test_suite='discogs_client.tests',
         classifiers=[
-            'Development Status :: 7 - Inactive',
+            'Development Status :: 5 - Production/Stable',
             'Environment :: Console',
             'License :: OSI Approved :: BSD License',
             'Natural Language :: English',


### PR DESCRIPTION
- As pointed out by @JOJ0 our 'Development Status' [on PyPI](https://pypi.org/project/python3-discogs-client/) is '7 - Inactive'
- This changes that to 'Development Status :: 5 - Production/Stable' 
- Once this is merged I'll upload it to PyPI so that it updates there 