### PR TITLE
More triggers to build on changes to PR 

### DIFF
--- a/.github/workflows/discogs_client-build.yml
+++ b/.github/workflows/discogs_client-build.yml
@@ -3,7 +3,7 @@ name: Build and test discogs_client
 on:
   push:
   pull_request:
-    types: [opened]
+    types: [opened, review_requested, synchronize, reopened, edited, ready_for_review]
 
 jobs:
   build:


### PR DESCRIPTION
- I have realised from [PR 18](https://github.com/joalla/discogs_client/pull/18) that there should be more triggers to build on changes to PR. Hopefully this achieves that
- Used [this article](https://frontside.com/blog/2020-05-26-github-actions-pull_request/#how-do-workflows-trigger-on-pull_request) for reference
- Side effect is mutiple work flows run for each trigger, but I think that is ok. From the article below:

> One thing to note is that when you configure your pull_request workflow to be triggered on labeled or unlabeled and you add/remove multiple labels at the same time, the event of each label will trigger its own workflow run. It also works the same way for assigned/unassigned and review_requested/review_request_removed.