### PR TITLE
Enums for condition, status and sort(by/order)

### DIFF
--- a/discogs_client/__init__.py
+++ b/discogs_client/__init__.py
@@ -3,4 +3,6 @@ __version__ = '2.2.2'
 
 from discogs_client.client import Client
 from discogs_client.models import Artist, Release, Master, Label, User, \
-    Listing, Track, Price, Video, List, ListItem
+    Listing, Track, Price, Video, List, ListItem, Inventory, Wantlist, \
+    WantlistItem, CollectionItemInstance, CollectionFolder, Order, OrderMessage, OrderMessagesList
+from discogs_client.utils import Condition, Sort, Status

--- a/discogs_client/tests/test_utils.py
+++ b/discogs_client/tests/test_utils.py
@@ -43,19 +43,19 @@ class UtilsTestCase(DiscogsClientTestCase):
 
     def test_condition(self):
         self.assertRaises(TypeError, lambda: utils.Condition())
-        self.assertTrue(utils.Condition.MINT, 'Mint (M)')
-        self.assertTrue(utils.Condition.NEAR_MINT, 'Near Mint (NM or M-)')
+        self.assertEqual(utils.Condition.MINT, 'Mint (M)')
+        self.assertEqual(utils.Condition.NEAR_MINT, 'Near Mint (NM or M-)')
 
     def test_status(self):
         self.assertRaises(TypeError, lambda: utils.Status())
-        self.assertTrue(utils.Status.DRAFT, 'Draft')
-        self.assertTrue(utils.Status.FOR_SALE, 'For Sale')
+        self.assertEqual(utils.Status.DRAFT, 'Draft')
+        self.assertEqual(utils.Status.FOR_SALE, 'For Sale')
 
     def test_sort(self):
         self.assertRaises(TypeError, lambda: utils.Sort())
-        self.assertTrue(utils.Sort.By.ARTIST, 'artist')
-        self.assertTrue(utils.Sort.Order.ASCENDING, 'asc')
-        self.assertTrue(utils.Sort.Order.DESCENDING, 'desc')
+        self.assertEqual(utils.Sort.By.ARTIST, 'artist')
+        self.assertEqual(utils.Sort.Order.ASCENDING, 'asc')
+        self.assertEqual(utils.Sort.Order.DESCENDING, 'desc')
 
 def suite():
     suite = unittest.TestSuite()

--- a/discogs_client/tests/test_utils.py
+++ b/discogs_client/tests/test_utils.py
@@ -41,6 +41,21 @@ class UtilsTestCase(DiscogsClientTestCase):
         self.assertEqual(p('2012-01-01T00:00:00'), datetime(2012, 1, 1, 0, 0, 0))
         self.assertEqual(p('2001-05-25T00:00:42'), datetime(2001, 5, 25, 0, 0, 42))
 
+    def test_condition(self):
+        self.assertRaises(TypeError, lambda: utils.Condition())
+        self.assertTrue(utils.Condition.MINT, 'Mint (M)')
+        self.assertTrue(utils.Condition.NEAR_MINT, 'Near Mint (NM or M-)')
+
+    def test_status(self):
+        self.assertRaises(TypeError, lambda: utils.Status())
+        self.assertTrue(utils.Status.DRAFT, 'Draft')
+        self.assertTrue(utils.Status.FOR_SALE, 'For Sale')
+
+    def test_sort(self):
+        self.assertRaises(TypeError, lambda: utils.Sort())
+        self.assertTrue(utils.Sort.By.ARTIST, 'artist')
+        self.assertTrue(utils.Sort.Order.ASCENDING, 'asc')
+        self.assertTrue(utils.Sort.Order.DESCENDING, 'desc')
 
 def suite():
     suite = unittest.TestSuite()

--- a/discogs_client/utils.py
+++ b/discogs_client/utils.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from urllib.parse import quote
+from enum import Enum
 
 
 def parse_timestamp(timestamp):
@@ -18,3 +19,65 @@ def update_qs(url, params):
 def omit_none(dict_):
     """Removes any key from a dict that has a value of None."""
     return {k: v for k, v in dict_.items() if v is not None}
+
+
+class Condition(Enum):
+    """Conditions for media and sleeve"""
+    MINT = 'Mint (M)'
+    NEAR_MINT = 'Near Mint (NM or M-)'
+    VERY_GOOD_PLUS = 'Very Good Plus (VG+)'
+    VERY_GOOD = 'Very Good (VG)'
+    GOOD_PLUS = 'Good Plus (G+)'
+    GOOD = 'Good (G)'
+    FAIR = 'Fair (F)'
+    POOR = 'Poor (P)'
+    # Special conditions for sleeve only
+    GENERIC = 'Generic'
+    NOT_GRADED = 'Not Graded'
+    NO_COVER = 'No Cover'
+
+    def __get__(self, object, type):
+        return self.value
+
+
+class Status(Enum):
+    """Status for a listing"""
+    FOR_SALE = 'For Sale'
+    DRAFT = 'Draft'
+    EXPIRED = 'Expired'
+
+    def __get__(self, object, type):
+        return self.value
+
+
+class Sort(Enum):
+    class By(Enum):
+        ADDED = 'added'
+        ARTIST = 'artist'
+        AUDIO = 'audio'
+        BUYER = 'buyer'
+        COUNTRY = 'country'
+        CREATED = 'created'
+        CATALOG_NUMBER = 'catno'
+        FORMAT = 'format'
+        ID = 'id'
+        ITEM = 'item'
+        LABEL = 'label'
+        LAST_ACTIVITY = 'last_activity'
+        LISTED = 'listed'
+        LOCATION = 'location'
+        PRICE = 'price'
+        RELEASED = 'released'
+        STATUS = 'status'
+        TITLE = 'title'
+        YEAR = 'year'
+
+    class Order(Enum):
+        ASCENDING = 'asc'
+        DESCENDING = 'desc'
+
+    # Return value of the child Enum item
+    def __getattr__(self, item):
+        if item != '_value_':
+            return getattr(self.value, item).value
+        raise AttributeError


### PR DESCRIPTION
also adds more imports to __init__.py

I tried to collect all strings I could find in the docs, there was three special conditions that the media condition does not accept but the sleeve condition does, `Generic`, `Not Graded` and `No Cover`