### PR TITLE
Update README python tag to code snippets for syntax highlighting

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -115,109 +115,145 @@ You can drill down as far as you like.
 
 Query for an artist using the artist's name:
 
-    >>> artist = d.artist(956139)
-    >>> print artist
-    <Artist "...">
-    >>> 'name' in artist.data.keys()
-    True
+```python
+>>> artist = d.artist(956139)
+>>> print artist
+<Artist "...">
+>>> 'name' in artist.data.keys()
+True
+```
 
 ### Special properties
 
 Get a list of `Artist`s representing this artist's aliases:
 
-    >>> artist.aliases
-    [...]
+```python
+>>> artist.aliases
+[...]
+```
 
 Get a list of `Release`s by this artist by page number:
 
-    >>> artist.releases.page(1)
-    [...]
+```python
+>>> artist.releases.page(1)
+[...]
+```
 
 ## Release
 
 Query for a release using its Discogs ID:
 
-    >>> release = d.release(221824)
+```python
+>>> release = d.release(221824)
+```
 
 ### Special properties
 
 Get the title of this `Release`:
 
-    >>> release.title
-    u'...'
+```python
+>>> release.title
+'...'
+```
 
 Get a list of all `Artist`s associated with this `Release`:
 
-    >>> release.artists
-    [<Artist "...">]
+```python
+>>> release.artists
+[<Artist "...">]
+```
 
 Get the tracklist for this `Release`:
 
-    >>> release.tracklist
-    [...]
+```python
+>>> release.tracklist
+[...]
+```
 
 Get the `MasterRelease` for this `Release`:
 
-    >>> release.master
-    <MasterRelease "...">
+```python
+>>> release.master
+<MasterRelease "...">
+```
 
 Get a list of all `Label`s for this `Release`:
 
-    >>> release.labels
-    [...]
+```python
+>>> release.labels
+[...]
+```
 
 ## MasterRelease
 
 Query for a master release using its Discogs ID:
 
-    >>> master_release = d.master(120735)
+```python
+>>> master_release = d.master(120735)
+```
 
 ### Special properties
 
 Get the key `Release` for this `MasterRelease`:
 
-    >>> master_release.main_release
-    <Release "...">
+```python
+>>> master_release.main_release
+<Release "...">
+```
 
 Get the title of this `MasterRelease`:
 
-    >>> master_release.title
-    u'...'
-    >>> master_release.title == master_release.main_release.title
-    True
+```python
+>>> master_release.title
+'...'
+>>> master_release.title == master_release.main_release.title
+True
+```
 
 Get a list of `Release`s representing other versions of this `MasterRelease` by page number:
 
-    >>> master_release.versions.page(1)
-    [...]
+```python
+>>> master_release.versions.page(1)
+[...]
+```
 
 Get the tracklist for this `MasterRelease`:
 
-    >>> master_release.tracklist
-    [...]
+```python
+>>> master_release.tracklist
+[...]
+```
 
 ## Label
 
 Query for a label using the label's name:
 
-    >>> label = d.label(6170)
+```python
+>>> label = d.label(6170)
+```
 
 ### Special properties
 
 Get a list of `Release`s from this `Label` by page number:
 
-    >>> label.releases.page(1)
-    [...]
+```python
+>>> label.releases.page(1)
+[...]
+```
 
 Get a list of `Label`s representing sublabels associated with this `Label`:
 
-    >>> label.sublabels
-    [...]
+```python
+>>> label.sublabels
+[...]
+```
 
 Get the `Label`'s parent label, if it exists:
 
-    >>> label.parent_label
-    <Label "Warp Records Limited">
+```python
+>>> label.parent_label
+<Label "Warp Records Limited">
+```
 
 ## Listing
 
@@ -246,6 +282,7 @@ listing.save()              # Save changes made to listing
 # Delete the listing
 listing.delete()
 ```
+
 ## Contributing
 1. Fork this repo
 2. Create a feature branch


### PR DESCRIPTION
Very minor change, but it always bugged me that some of the code snippets in the README used the python syntax hinter and some did not 😄 I also removed the `u'...'` prefix as unicode is default in python 3, this is left over from the python 2 days.

