### PR TITLE
Release version check gh-actions workflow

### DIFF
--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -1,11 +1,11 @@
-name: Compare setup.py and release tag versions
+name: Release version check
 
 on:
   push:
     tags:
       - 'v*'
   release:
-    types: [created, published]
+    types: [created, published, edited, prereleased, released]
 
 jobs:
   check_versions:
@@ -13,7 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v2
+    - name: Checkout
+      uses: actions/checkout@v2
 
     - name: Set up Python 3.9
       uses: actions/setup-python@v2
@@ -27,21 +28,14 @@ jobs:
         echo "setup_version=$VERSION" >> $GITHUB_ENV
         echo "tag_version=$TAG" >> $GITHUB_ENV
 
-    - name: Compare versions inside environment
+    - name: Compare versions and report
       run: |
         echo "setup.py version: ${{ env.setup_version }}"
         echo "Latest tag version: ${{ env.tag_version }}"
         if [[ ${{ env.setup_version }} != ${{ env.tag_version }} ]]; then
-          echo "Warn user and quit workflow."
+          echo "Versions are not identical, quitting workflow..."
+          exit 23
         else
-          echo "Continue workflow - possibly even create release?"
+          echo "OK, versions match - possibly even create release?"
+          exit 0
         fi
-
-    #${{ github.event.release.tag_name }}"
-    ##- uses: oprypin/find-latest-tag@v1
-    ##  with:
-    ##    repository: discogs_client/rest.js  # The repository to scan.
-    ##    releases-only: true  # We know that all relevant tags have a GitHub release for them.
-    ##  id: joalla  # The step ID to refer to later.
- 
-    #- run: echo "Latest release tag is at version ${{ steps.joalla.outputs.tag }}"

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -1,0 +1,47 @@
+name: Compare setup.py and release tag versions
+
+on:
+  push:
+    tags:
+      - 'v*'
+  release:
+    types: [created, published]
+
+jobs:
+  check_versions:
+
+    runs-on: ubuntu-latest
+    steps:
+
+    - uses: actions/checkout@v2
+
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+
+    - name: Get versions into environment
+      run: |
+        VERSION=$(python setup.py --version)
+        TAG=${GITHUB_REF##*/v}
+        echo "setup_version=$VERSION" >> $GITHUB_ENV
+        echo "tag_version=$TAG" >> $GITHUB_ENV
+
+    - name: Compare versions inside environment
+      run: |
+        echo "setup.py version: ${{ env.setup_version }}"
+        echo "Latest tag version: ${{ env.tag_version }}"
+        if [[ ${{ env.setup_version }} != ${{ env.tag_version }} ]]; then
+          echo "Warn user and quit workflow."
+        else
+          echo "Continue workflow - possibly even create release?"
+        fi
+
+    #${{ github.event.release.tag_name }}"
+    ##- uses: oprypin/find-latest-tag@v1
+    ##  with:
+    ##    repository: discogs_client/rest.js  # The repository to scan.
+    ##    releases-only: true  # We know that all relevant tags have a GitHub release for them.
+    ##  id: joalla  # The step ID to refer to later.
+ 
+    #- run: echo "Latest release tag is at version ${{ steps.joalla.outputs.tag }}"


### PR DESCRIPTION
As a first step of automating our release process, this is just a simple comparison of version in setup.py and the latest (release) tag in the repo.

* Triggers on all release related actions (create, publish, edit, ....) except the unpublish action.
* Triggers when pushing a version tag (v...)
* Gets version from setup.py and latest git tag into the workflow environment
* Compares them and exits accordingly

I tested this in my fork, it seems to run stable, doesn't actually block anything and it is independent of our "build and test" workflow.