### PR TITLE
Add MarketplaceStats API endpoint

### DIFF
--- a/discogs_client/models.py
+++ b/discogs_client/models.py
@@ -507,8 +507,29 @@ class Release(PrimaryAPIObject):
         else:
             return None
 
+    @property
+    def marketplace_stats(self):
+        release_id = self.fetch('id')
+        if release_id:
+            return MarketplaceStats(self.client, {'id': release_id})
+        else:
+            return None
+
     def __repr__(self):
         return '<Release {0!r} {1!r}>'.format(self.id, self.title)
+
+
+class MarketplaceStats(PrimaryAPIObject):
+    num_for_sale = SimpleField()
+    blocked_from_sale = SimpleField()
+    lowest_price = ObjectField('Price')
+
+    def __init__(self, client, dict_):
+        super(MarketplaceStats, self).__init__(client, dict_)
+        self.data['resource_url'] = '{0}/marketplace/stats/{1}'.format(client._base_url, dict_['id'])
+
+    def __repr__(self):
+        return '<MarketplaceStats {0!r} for sale>'.format(self.num_for_sale)
 
 
 class Master(PrimaryAPIObject):
@@ -792,6 +813,7 @@ class ListItem(SecondaryAPIObject):
 CLASS_MAP = {
     'artist': Artist,
     'release': Release,
+    'marketplacestats': MarketplaceStats,
     'master': Master,
     'label': Label,
     'price': Price,

--- a/discogs_client/tests/res/marketplace/stats/1.json
+++ b/discogs_client/tests/res/marketplace/stats/1.json
@@ -1,0 +1,7 @@
+{
+  "num_for_sale": 10,
+  "lowest_price": {
+    "value": 100,
+    "currency": "EUR"
+  }
+}

--- a/discogs_client/tests/test_models.py
+++ b/discogs_client/tests/test_models.py
@@ -206,7 +206,7 @@ class ModelsTestCase(DiscogsClientTestCase):
             'allow_offers': False,
         }
         self.assertEqual(listing.changes, expected)
-        
+
         # Test saving
         listing.save()
         method, url, data, headers = self.d._fetcher.requests[2]
@@ -282,6 +282,20 @@ class ModelsTestCase(DiscogsClientTestCase):
         me = self.d.identity()
         self.assertEqual(me.data['consumer_name'], 'Test Client')
         self.assertEqual(me, self.d.user('example'))
+
+    def test_marketplace_stats(self):
+        """Release stats can be fetched and parsed"""
+        stats = self.d.release(1).marketplace_stats
+
+        # Assert that returned stats are correct.
+        self.assertEqual(stats.num_for_sale, 10)
+        self.assertEqual(stats.lowest_price.value, 100)
+        self.assertEqual(stats.lowest_price.currency, 'EUR')
+
+        # Assert that request URL and method is correct.
+        method, url, data, headers = self.d._fetcher.requests[0]
+        self.assertEqual(method, 'GET')
+        self.assertEqual(url, '/marketplace/stats/1')
 
 
 def suite():


### PR DESCRIPTION
I have extended the Python module with the `/marketplace/stats/{release_id}{?curr_abbr}` API endpoint. This endpoint exposes some Marketplace pricing information about a release. More information about this endpoint [here](https://www.discogs.com/developers#page:marketplace,header:marketplace-release-statistics).
