### PR TITLE
Added a user's Collection Value

### DIFF
--- a/discogs_client/models.py
+++ b/discogs_client/models.py
@@ -609,6 +609,11 @@ class User(PrimaryAPIObject):
         resp = self.client._get(self.fetch('collection_folders_url'))
         return [CollectionFolder(self.client, d) for d in resp['folders']]
 
+    @property
+    def collection_value(self):
+        resp = self.client._get(f"{self.fetch('resource_url')}/collection/value")
+        return CollectionValue(self.client, resp)
+
     def __repr__(self):
         return '<User {0!r} {1!r}>'.format(self.id, self.username)
 
@@ -642,6 +647,18 @@ class CollectionItemInstance(PrimaryAPIObject):
 
     def __repr__(self):
         return '<CollectionItemInstance {0!r} {1!r}>'.format(self.id, self.release.title)
+
+
+class CollectionValue(PrimaryAPIObject):
+    maximum = SimpleField()
+    median = SimpleField()
+    minimum = SimpleField()
+
+    def __init__(self, client, dict_):
+        super(CollectionValue, self).__init__(client, dict_)
+
+    def __repr__(self):
+        return f"<CollectionValue {self.median}>"
 
 
 class CollectionFolder(PrimaryAPIObject):
@@ -826,4 +843,5 @@ CLASS_MAP = {
     'listing': Listing,
     'wantlistitem': WantlistItem,
     'ordermessage': OrderMessage,
+    'collectionvalue': CollectionValue,
 }

--- a/discogs_client/tests/res/users/example/collection/value.json
+++ b/discogs_client/tests/res/users/example/collection/value.json
@@ -1,0 +1,1 @@
+{"median": "£2.50", "minimum":"£1.05", "maximum":"£5"}

--- a/discogs_client/tests/test_models.py
+++ b/discogs_client/tests/test_models.py
@@ -1,5 +1,5 @@
 import unittest
-from discogs_client.models import Artist, Release, ListItem
+from discogs_client.models import Artist, Release, ListItem, CollectionValue
 from discogs_client.tests import DiscogsClientTestCase
 from discogs_client.exceptions import HTTPError
 
@@ -296,6 +296,20 @@ class ModelsTestCase(DiscogsClientTestCase):
         method, url, data, headers = self.d._fetcher.requests[0]
         self.assertEqual(method, 'GET')
         self.assertEqual(url, '/marketplace/stats/1')
+
+    def test_collection_value(self):
+        """Collection Value can be fetched and parsed"""
+        u = self.d.user("example")
+
+        self.assertEqual(isinstance(u.collection_value, CollectionValue), True)
+        self.assertEqual(u.collection_value.minimum, "£1.05")
+        self.assertEqual(u.collection_value.maximum, "£5")
+        self.assertEqual(u.collection_value.median, "£2.50")
+
+        # Assert that request URL and method is correct.
+        method, url, data, headers = self.d._fetcher.requests[0]
+        self.assertEqual(method, "GET")
+        self.assertEqual(url, "/users/example/collection/value")
 
 
 def suite():


### PR DESCRIPTION
- As per request in the discussions [here](https://github.com/joalla/discogs_client/discussions/54#discussion-3371600), we haven't included the ability to fetch a user's collection value ([this endpoint](https://www.discogs.com/developers#page:user-collection,header:user-collection-collection-value))
- Unfortunately it seems like the API is limited to the fact it will give us the 'All' folders value, and not individual folder values
- Also it is set in the currency that your profile is in, it can be changed through the UI