### PR TITLE
Fix __version__ and get rid of __version_info__

### DIFF
--- a/discogs_client/__init__.py
+++ b/discogs_client/__init__.py
@@ -1,5 +1,4 @@
-__version_info__ = 2, 2, 2
-__version__ = '2.2.2'
+__version__ = '2.3.12'
 
 from discogs_client.client import Client
 from discogs_client.models import Artist, Release, Master, Label, User, \

--- a/discogs_client/__init__.py
+++ b/discogs_client/__init__.py
@@ -1,4 +1,5 @@
 __version__ = '2.3.12'
+__version_info__ = tuple(int(i) for i in __version__.split('.') if i.isdigit())
 
 from discogs_client.client import Client
 from discogs_client.models import Artist, Release, Master, Label, User, \


### PR DESCRIPTION
Fixing `__version__` shouldn't hurt, removing `__version_info__` entirely is a proposal. Tell me what you think @AnssiAhola and @alifhughes.
Some details in the commit message.