### PR TITLE
add method to fetch users collection items by release

### DIFF
--- a/discogs_client/models.py
+++ b/discogs_client/models.py
@@ -637,11 +637,18 @@ class User(PrimaryAPIObject):
         return [CollectionFolder(self.client, d) for d in resp['folders']]
 
     def collection_items(self, release):
-        """
-        Fetch collection items by release, accepts Release object or release id
+        """Fetch collection items by release, accepts Release object or release id
 
-        Returns paginated list of CollectionItemInstance objects
+        Parameters
+        ----------
+        release : Release or int
+
+        Returns
+        -------
+        PaginatedList
+            PaginatedList of CollectionItemInstance objects
         """
+
         release_id = release.id if isinstance(release, Release) else release
         return PaginatedList(self.client,self.fetch('resource_url') + "/collection/releases/{}".format(release_id) , "releases", CollectionItemInstance)
 

--- a/discogs_client/models.py
+++ b/discogs_client/models.py
@@ -636,6 +636,11 @@ class User(PrimaryAPIObject):
         resp = self.client._get(self.fetch('collection_folders_url'))
         return [CollectionFolder(self.client, d) for d in resp['folders']]
 
+    # TODO: Come up with a better name and whether this should be here
+    def collectionitems_by_release(self, release):
+        release_id = release.id if isinstance(release, Release) else release
+        return PaginatedList(self.client,self.fetch('resource_url') + "/collection/releases/{}".format(release_id) , "releases", CollectionItemInstance)
+
     @property
     def collection_value(self):
         resp = self.client._get(f"{self.fetch('resource_url')}/collection/value")

--- a/discogs_client/models.py
+++ b/discogs_client/models.py
@@ -636,8 +636,12 @@ class User(PrimaryAPIObject):
         resp = self.client._get(self.fetch('collection_folders_url'))
         return [CollectionFolder(self.client, d) for d in resp['folders']]
 
-    # TODO: Come up with a better name and whether this should be here
-    def collectionitems_by_release(self, release):
+    def collection_items(self, release):
+        """
+        Fetch collection items by release, accepts Release object or release id
+
+        Returns paginated list of CollectionItemInstance objects
+        """
         release_id = release.id if isinstance(release, Release) else release
         return PaginatedList(self.client,self.fetch('resource_url') + "/collection/releases/{}".format(release_id) , "releases", CollectionItemInstance)
 


### PR DESCRIPTION
WIP

Implements [this API point](https://www.discogs.com/developers/#page:user-collection,header:user-collection-collection-items-by-release) as requested by @raratiru in #90
closes #90 

@JOJ0 @alifhughes If either of you could tell me what you think

Usage
```python

release_instances = me.collection_items(22155985)
for instance in release_instances:
    print(instance) 
```
Once you have the instance you can get the collection folder it belong to and delete it (or do whatever)
```python
folder = me.collection_folders[instance.folder_id]
folder.remove_release(instance)
```
Not the most elegant but thats how the discogs api is sometimes :woman_shrugging: 