### PR TITLE
Fix dependency handling

### DIFF
--- a/.github/workflows/discogs_client-build.yml
+++ b/.github/workflows/discogs_client-build.yml
@@ -22,6 +22,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install .
+        pip install nose coverage
     - name: Run Tests with coverage
       run: |
         if [ $(python -c "import sys; print(sys.version_info.minor)") -lt 7 ]; then

--- a/.github/workflows/discogs_client-build.yml
+++ b/.github/workflows/discogs_client-build.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
+        pip install .
     - name: Run Tests with coverage
       run: |
         if [ $(python -c "import sys; print(sys.version_info.minor)") -lt 7 ]; then

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,2 @@
-nose==1.3.7
-PyYAML==4.2b1
-coverage==5.0.3
-coveralls==0.2
-docopt==0.6.1
-requests==2.20.0
-oauthlib==0.7.2
-sh==1.08
-python-dateutil==2.8.1
+nose
+coverage

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,3 @@ requests==2.20.0
 oauthlib==0.7.2
 sh==1.08
 python-dateutil==2.8.1
-
-Sphinx==3.5.4
-sphinx-rtd-theme==0.5.2
-myst-parser==0.13.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,0 @@
-nose==1.3.7
-PyYAML==4.2b1
-coverage==5.0.3
-coveralls==0.2
-docopt==0.6.1
-requests==2.20.0
-oauthlib==0.7.2
-sh==1.08
-python-dateutil==2.8.1

--- a/sphinx_requirements.txt
+++ b/sphinx_requirements.txt
@@ -1,13 +1,4 @@
-nose==1.3.7
-PyYAML==4.2b1
-coverage==5.0.3
-coveralls==0.2
-docopt==0.6.1
-requests==2.20.0
-oauthlib==0.7.2
-sh==1.08
-python-dateutil==2.8.1
-
-Sphinx==3.5.4
-sphinx-rtd-theme==0.5.2
-myst-parser==0.13.7
+Jinja2<3.1
+Sphinx
+sphinx-rtd-theme
+myst-parser

--- a/sphinx_requirements.txt
+++ b/sphinx_requirements.txt
@@ -1,13 +1,3 @@
-nose==1.3.7
-PyYAML==4.2b1
-coverage==5.0.3
-coveralls==0.2
-docopt==0.6.1
-requests==2.20.0
-oauthlib==0.7.2
-sh==1.08
-python-dateutil==2.8.1
-
 Sphinx==3.5.4
 sphinx-rtd-theme==0.5.2
 myst-parser==0.13.7


### PR DESCRIPTION
Since recently we realized that our requirements.txt is wrong anyway (https://github.com/joalla/discogs_client/pull/99), I propse we kick it out. Regular installs from git use the deps provided in setup.py anway.

Users/devs who want to add to our docs should then be advised to simply install additional requirements from the simplified sphinx_requirements.txt file.

Also this PR should address the security vulnerabilites detected by dependabot: https://github.com/joalla/discogs_client/security/dependabot