### PR TITLE
Add community details to Release

### DIFF
--- a/discogs_client/models.py
+++ b/discogs_client/models.py
@@ -494,6 +494,7 @@ class Release(PrimaryAPIObject):
     credits = ListField('Artist', key='extraartists')
     labels = ListField('Label')
     companies = ListField('Label')
+    community = ObjectField("communitydetails")
 
     def __init__(self, client, dict_):
         super(Release, self).__init__(client, dict_)
@@ -877,6 +878,27 @@ class ListItem(SecondaryAPIObject):
         return '<ListItem {0!r}>'.format(self.id)
 
 
+class CommunityDetails(SecondaryAPIObject):
+    status = SimpleField()
+    data_quality = SimpleField()
+    want = SimpleField()
+    have = SimpleField()
+    rating = ObjectField('Rating')
+    contributors = ListField("User")
+    submitter = ObjectField("User")
+
+    def __repr__(self):
+        return '<CommunityDetails want/have: {0!r}/{1!r}>'.format(self.want, self.have)
+
+
+class Rating(SecondaryAPIObject):
+    count = SimpleField()
+    average = SimpleField()
+
+    def __repr__(self):
+        return '<Rating avg: {0!r}>'.format(self.average)
+
+
 CLASS_MAP = {
     'artist': Artist,
     'release': Release,
@@ -895,4 +917,6 @@ CLASS_MAP = {
     'wantlistitem': WantlistItem,
     'ordermessage': OrderMessage,
     'collectionvalue': CollectionValue,
+    'communitydetails': CommunityDetails,
+    'rating': Rating,
 }


### PR DESCRIPTION
Adds community related fields from [GET Release API](https://www.discogs.com/developers#page:database,header:database-release-get)

closes #104

Usage
```python
release = client.release(15343679)
community_details = release.community

print(community_details)
>>> <CommunityDetails want/have: 34/74>
print (community_details.rating)
>>> <Rating avg: 4.5>
print(community_details.want)
>>> 34
print(community_details.have)
>>> 74
print(community_details.status)
>>> Accepted
print(community_details.data_quality)
>>> Needs Vote
print(community_details.contributors)
>>> [<User 1053297 'ManikRecs'>, <User 1241908 'neurosis76'>, <User 8867757 'silyn1'>, <User 3410038 'evasstra'>]
print(community_details.submitter)
>>> <User 1053297 'ManikRecs'>
```