### PR TITLE
Add python 3.10 to github actions

### DIFF
--- a/.github/workflows/discogs_client-build.yml
+++ b/.github/workflows/discogs_client-build.yml
@@ -25,8 +25,4 @@ jobs:
         pip install nose coverage
     - name: Run Tests with coverage
       run: |
-        if [ $(python -c "import sys; print(sys.version_info.minor)") -lt 7 ]; then
-            nosetests
-        else
-            nosetests --with-coverage --cover-package=discogs_client
-        fi
+        python -m unittest

--- a/.github/workflows/discogs_client-build.yml
+++ b/.github/workflows/discogs_client-build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/discogs_client-build.yml
+++ b/.github/workflows/discogs_client-build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
Tests for python 3.10 fail if using `nose`.
This is because nose is no longer maintained and uses `collection.Callable` which was [removed in 3.10](https://docs.python.org/3/whatsnew/3.10.html#removed)

Switched to using `unittest` which works fine.
Might be wise to remove the whole dependency to `nose`

Even thought the tests pass with 3.10, I don't think that's a guarantee that the client works in 3.10 completely without issues