### PR TITLE
Add timeout to requests

### DIFF
--- a/discogs_client/client.py
+++ b/discogs_client/client.py
@@ -1,4 +1,5 @@
 import json
+from typing import Union
 from urllib.parse import urlencode
 
 from discogs_client import models
@@ -193,3 +194,20 @@ class Client:
         if not isinstance(value, bool):
             raise ValueError("Backoff enabled toggle should be of type bool")
         self._fetcher.backoff_enabled = value
+
+    @property
+    def timeout(self):
+        """Return current client timeout parameters as tuple (connect, read)"""
+        return (self._fetcher.connect_timeout, self._fetcher.read_timeout)
+
+    def set_timeout(self,
+                    connect: Union[int, float] = 5,
+                    read: Union[int, float] = 10) -> None:
+        """Set request timeout parameters
+
+        Args:
+            connect (Union[int, float], optional): Time in seconds after which connect will timeout. Defaults to 5.
+            read (Union[int, float], optional): Time in seconds after which request will timeout. Defaults to 10.
+        """
+        self._fetcher.connect_timeout = connect
+        self._fetcher.read_timeout = read

--- a/discogs_client/client.py
+++ b/discogs_client/client.py
@@ -196,9 +196,14 @@ class Client:
         self._fetcher.backoff_enabled = value
 
     @property
-    def timeout(self):
-        """Return current client timeout parameters as tuple (connect, read)"""
-        return (self._fetcher.connect_timeout, self._fetcher.read_timeout)
+    def connection_timeout(self):
+        """Return current client connection timeout"""
+        return self._fetcher.connect_timeout
+
+    @property
+    def read_timeout(self):
+        """Return current client read timeout"""
+        return self._fetcher.read_timeout
 
     def set_timeout(self,
                     connect: Union[int, float] = 5,

--- a/discogs_client/client.py
+++ b/discogs_client/client.py
@@ -205,9 +205,12 @@ class Client:
                     read: Union[int, float] = 10) -> None:
         """Set request timeout parameters
 
-        Args:
-            connect (Union[int, float], optional): Time in seconds after which connect will timeout. Defaults to 5.
-            read (Union[int, float], optional): Time in seconds after which request will timeout. Defaults to 10.
+        Parameters
+        ----------
+            connect : (Union[int, float], optional)
+                Time in seconds after which connect will timeout. Defaults to 5.
+            read : (Union[int, float], optional)
+                Time in seconds after which request will timeout. Defaults to 10.
         """
         self._fetcher.connect_timeout = connect
         self._fetcher.read_timeout = read

--- a/discogs_client/fetchers.py
+++ b/discogs_client/fetchers.py
@@ -1,4 +1,3 @@
-import requests
 from requests.api import request
 from oauthlib import oauth1
 import json
@@ -6,6 +5,7 @@ import os
 import re
 from discogs_client.utils import backoff
 from urllib.parse import parse_qsl
+from typing import Union
 
 
 class Fetcher:
@@ -16,6 +16,8 @@ class Fetcher:
     (It's a slightly leaky abstraction designed to make testing easier.)
     """
     backoff_enabled = True
+    connect_timeout: Union[float, None] = None
+    read_timeout: Union[float, None] = None
 
     def fetch(self, client, method, url, data=None, headers=None, json=True):
         """Fetch the given request
@@ -52,8 +54,11 @@ class Fetcher:
 
     @backoff
     def request(self, method, url, data, headers, params=None):
-        response = request(method=method, url=url, data=data, headers=headers, params=params)
-        return response
+        return request(
+            method=method, url=url, data=data,
+            headers=headers, params=params,
+            timeout=(self.connect_timeout, self.read_timeout)
+        )
 
 
 class LoggingDelegator:

--- a/discogs_client/fetchers.py
+++ b/discogs_client/fetchers.py
@@ -16,8 +16,8 @@ class Fetcher:
     (It's a slightly leaky abstraction designed to make testing easier.)
     """
     backoff_enabled = True
-    connect_timeout: Union[float, None] = None
-    read_timeout: Union[float, None] = None
+    connect_timeout: Union[float, int, None] = None
+    read_timeout: Union[float, int, None] = None
 
     def fetch(self, client, method, url, data=None, headers=None, json=True):
         """Fetch the given request

--- a/discogs_client/tests/test_core.py
+++ b/discogs_client/tests/test_core.py
@@ -116,8 +116,8 @@ class CoreTestCase(DiscogsClientTestCase):
         # self.d would throw AttributeError trying to access timeout properties on LoggingDelegator
         client = Client('')
         client._fetcher = MemoryFetcher({})
-        self.assertEqual(None, self.d.connection_timeout)
-        self.assertEqual(None, self.d.read_timeout)
+        self.assertEqual(None, client.connection_timeout)
+        self.assertEqual(None, client.read_timeout)
 
     def test_set_timeout_in_float(self):
         self.d.set_timeout(connect=1.23, read=7.42)

--- a/discogs_client/tests/test_core.py
+++ b/discogs_client/tests/test_core.py
@@ -120,19 +120,26 @@ class CoreTestCase(DiscogsClientTestCase):
 
     def test_set_timeout_in_float(self):
         self.d.set_timeout(connect=1.23, read=7.42)
-        self.assertEqual((1.23, 7.42), self.d.timeout)
+        self.assertEqual(1.23, self.d.connection_timeout)
+        self.assertEqual(7.42, self.d.read_timeout)
 
     def test_set_timeout_in_int(self):
-        self.d.set_timeout(connect=3, read=6)
-        self.assertEqual((3, 6), self.d.timeout)
+        self.d.set_timeout(connect=3, read=6)        
+        self.assertEqual(3, self.d.connection_timeout)
+        self.assertEqual(6, self.d.read_timeout)
 
     def test_set_timeout_to_none(self):
         self.d.set_timeout(connect=5, read=None)
-        self.assertEqual((5, None), self.d.timeout)
+        self.assertEqual(5, self.d.connection_timeout)
+        self.assertEqual(None, self.d.read_timeout)
+
         self.d.set_timeout(connect=None, read=10)
-        self.assertEqual((None, 10), self.d.timeout)
+        self.assertEqual(None, self.d.connection_timeout)
+        self.assertEqual(10, self.d.read_timeout)
+
         self.d.set_timeout(connect=None, read=None)
-        self.assertEqual((None, None), self.d.timeout)
+        self.assertEqual(None, self.d.connection_timeout)
+        self.assertEqual(None, self.d.read_timeout)
 
 
 def suite():

--- a/discogs_client/tests/test_core.py
+++ b/discogs_client/tests/test_core.py
@@ -1,5 +1,6 @@
 import unittest
 from discogs_client import Client
+from discogs_client.fetchers import MemoryFetcher
 from discogs_client.tests import DiscogsClientTestCase
 from discogs_client.exceptions import ConfigurationError, HTTPError
 from datetime import datetime
@@ -109,6 +110,29 @@ class CoreTestCase(DiscogsClientTestCase):
         # Changing pagination settings invalidates the cache
         results.per_page = 10
         self.assertTrue(results._num_pages is None)
+
+    def test_timeout_defaults_to_none(self):
+        # Need to create client without LoggingDelegator here
+        # self.d would throw AttributeError trying to access timeout properties on LoggingDelegator
+        client = Client('')
+        client._fetcher = MemoryFetcher({})
+        self.assertEqual((None, None), client.timeout)
+
+    def test_set_timeout_in_float(self):
+        self.d.set_timeout(connect=1.23, read=7.42)
+        self.assertEqual((1.23, 7.42), self.d.timeout)
+
+    def test_set_timeout_in_int(self):
+        self.d.set_timeout(connect=3, read=6)
+        self.assertEqual((3, 6), self.d.timeout)
+
+    def test_set_timeout_to_none(self):
+        self.d.set_timeout(connect=5, read=None)
+        self.assertEqual((5, None), self.d.timeout)
+        self.d.set_timeout(connect=None, read=10)
+        self.assertEqual((None, 10), self.d.timeout)
+        self.d.set_timeout(connect=None, read=None)
+        self.assertEqual((None, None), self.d.timeout)
 
 
 def suite():

--- a/discogs_client/tests/test_core.py
+++ b/discogs_client/tests/test_core.py
@@ -116,7 +116,8 @@ class CoreTestCase(DiscogsClientTestCase):
         # self.d would throw AttributeError trying to access timeout properties on LoggingDelegator
         client = Client('')
         client._fetcher = MemoryFetcher({})
-        self.assertEqual((None, None), client.timeout)
+        self.assertEqual(None, self.d.connection_timeout)
+        self.assertEqual(None, self.d.read_timeout)
 
     def test_set_timeout_in_float(self):
         self.d.set_timeout(connect=1.23, read=7.42)

--- a/docs/source/quickstart.md
+++ b/docs/source/quickstart.md
@@ -79,7 +79,7 @@ release.data.keys()
 
 ## Request timeouts
 
-By default the {class}`discogs_client.client.Client` does not timeout requests.
+By default the {class}`.Client` does not timeout requests.
 
 You can enable request timeouts like so
 

--- a/docs/source/quickstart.md
+++ b/docs/source/quickstart.md
@@ -77,3 +77,18 @@ release = d.release(1)
 release.data.keys()
 ```
 
+## Request timeouts
+
+By default the {class}`discogs_client.client.Client` does not timeout requests.
+
+You can enable request timeouts like so
+
+```python
+timeout_in_seconds = 5
+client.timeout(
+    connect=timeout_in_seconds,
+    read=timeout_in_seconds
+)
+```
+
+_Timeouts support integer and float values, you can also set either value to `None` to disable timeout for connect or read separately_


### PR DESCRIPTION
Adds (optional) request timeout to the client as requested by @aw-was-here in #120 

Adds properties `connect_timeout` and `read_timeout` to base class `Fetcher`
Will use those properties and pass them to [`requests.request`](https://requests.readthedocs.io/en/latest/api/#requests.request) function as a tuple

These new properties are `None` by default as to not "break" existing apps etc.
Note. They are also None by default if not provided to the `requests.request` function [see link](https://requests.readthedocs.io/en/latest/user/advanced/#timeouts), kind of surprised this hasnt come up sooner :smile:

Usage:
```python
client = Client(my_client_name,user_token=my_token)
client.set_timeout(read=0.5)

user = client.user("MrJuusto")
for folder in user.collection_folders:
    for release in folder.releases:
        print(release)

>>> Traceback (most recent call last):
>>> ...
>>> requests.exceptions.ReadTimeout: HTTPSConnectionPool(host='api.discogs.com', port=443): Read timed out. (read timeout=0.5)
```

Closes #120 

@alifhughes @JOJ0 Feedback is appreciated :smiley: 

@aw-was-here
If you want to test it for yourself before release, that would be appreciated as well :sweat_smile: 
[See our docs](https://python3-discogs-client.readthedocs.io/en/latest/contribution.html#testing-an-unreleased-feature) on how to do that if you're not familiar already