### PR TITLE
Edit docs - Add section with example of getting a user's inventory

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -11,7 +11,7 @@ It also supports OAuth 1.0a authorization, which allows you to change user data
 such as profile information, collections and wantlists, inventory, and orders.
 
 Find usage information [on our documentation pages](
-<https://python3-discogs-client.readthedocs.org>),
+https://python3-discogs-client.readthedocs.org),
 ask for help, suggest features and help others in the [discussion section of our
 github repo](https://github.com/joalla/discogs_client/discussions). If you'd
 like to contribute your code, you are welcome to submit a pull-request as
@@ -22,8 +22,8 @@ Client"](https://www.discogs.com/forum/thread/822690) on the Discogs developer
 forum we use to announce releases and other news.
 
 [![Coverage Status](
-<https://coveralls.io/repos/github/joalla/discogs_client/badge.svg>)](
-<https://coveralls.io/github/joalla/discogs_client>)
+https://coveralls.io/repos/github/joalla/discogs_client/badge.svg)](
+https://coveralls.io/github/joalla/discogs_client)
 
 ## Installation
 
@@ -45,22 +45,24 @@ $ pip3 install python3-discogs-client
 
 _For more information, have a look at the
 [quickstart section](
-<https://python3-discogs-client.readthedocs.org/en/latest/quickstart.html>)
+https://python3-discogs-client.readthedocs.org/en/latest/quickstart.html)
 in our documentation pages._
+
 
 ### Authorization
 
 There are two different authorization methods you can choose from depending on
 your requirements:
 [User-token](
-<https://python3-discogs-client.readthedocs.org/en/latest/authentication.html#user-token-authorization>)
+https://python3-discogs-client.readthedocs.org/en/latest/authentication.html#user-token-authorization)
 and [OAuth](
-<https://python3-discogs-client.readthedocs.org/en/latest/authentication.html#oauth-authorization>)
+https://python3-discogs-client.readthedocs.org/en/latest/authentication.html#oauth-authorization)
 authentication.
 
 _Note that Authorization is an optional feature of the Discogs API but a lot of
 basic functionality, like searching for releases, artists, etc. requires users
 being authenticated already._
+
 
 #### User-token authentication
 
@@ -69,7 +71,7 @@ requiring authentication, such as search (see below).
 
 For this, you'll need to
 [generate a user-token from your developer settings](
-<https://python3-discogs-client.readthedocs.org/en/latest/authentication.html#user-token-authentication>)
+https://python3-discogs-client.readthedocs.org/en/latest/authentication.html#user-token-authentication)
 on the Discogs website.
 
 ```python
@@ -79,6 +81,7 @@ on the Discogs website.
 _Head to the [authentication
 section](https://python3-discogs-client.readthedocs.org/en/latest/authentication.html#oauth-authentication)
 in our docs to learn about the OAuth authentication method._
+
 
 ### Fetching data
 
@@ -113,10 +116,11 @@ You can drill down as far as you like.
 
 _Have a look at the
 [searching](
-<https://python3-discogs-client.readthedocs.org/en/latest/quickstart.html#searching>)
+https://python3-discogs-client.readthedocs.org/en/latest/quickstart.html#searching)
 and [fetching data](
-<https://python3-discogs-client.readthedocs.org/en/latest/fetching_data.html>)
+https://python3-discogs-client.readthedocs.org/en/latest/fetching_data.html)
 sections in our documentation pages._
+
 
 ## Marketplace listing
 
@@ -155,8 +159,9 @@ me.inventory.add_listing(
 
 _To learn how to update your inventory and delete listings, have a look at the
 [marketplace listing section](
-<https://python3-discogs-client.readthedocs.org/en/latest/listing.html>) in our
+https://python3-discogs-client.readthedocs.org/en/latest/listing.html) in our
 docs._
+
 
 ## For more information
 
@@ -164,6 +169,7 @@ docs._
 - Check the [discogs_client Python package documentation](https://python3-discogs-client.readthedocs.org/en/latest/discogs_client.html) to find out details on specific modules, classes, methods, and more.
 - Or just spin up a REPL and use `dir()` on things :)
 - If you have questions or feature requests, please ask in the [discussion section](https://github.com/joalla/discogs_client/discussions).
+
 
 ## Contributing
 

--- a/README.mkd
+++ b/README.mkd
@@ -124,7 +124,7 @@ sections in our documentation pages._
 
 ## Marketplace listing
 
-Getting listings/releases from a user's inventory (this does not require authentication)
+Get listings/releases from a user's inventory (this does not require authentication)
 
 ```python
 >>> user = d.user('username')

--- a/README.mkd
+++ b/README.mkd
@@ -31,7 +31,7 @@ Install [the client from PyPI](https://pypi.org/project/python3-discogs-client/)
 using your favorite package manager.
 
 ```sh
-pip3 install python3-discogs-client
+$ pip3 install python3-discogs-client
 ```
 
 ## Quickstart
@@ -48,7 +48,6 @@ _For more information, have a look at the
 <https://python3-discogs-client.readthedocs.org/en/latest/quickstart.html>)
 in our documentation pages._
 
-
 ### Authorization
 
 There are two different authorization methods you can choose from depending on
@@ -62,7 +61,6 @@ authentication.
 _Note that Authorization is an optional feature of the Discogs API but a lot of
 basic functionality, like searching for releases, artists, etc. requires users
 being authenticated already._
-
 
 #### User-token authentication
 
@@ -81,7 +79,6 @@ on the Discogs website.
 _Head to the [authentication
 section](https://python3-discogs-client.readthedocs.org/en/latest/authentication.html#oauth-authentication)
 in our docs to learn about the OAuth authentication method._
-
 
 ### Fetching data
 
@@ -121,7 +118,6 @@ and [fetching data](
 <https://python3-discogs-client.readthedocs.org/en/latest/fetching_data.html>)
 sections in our documentation pages._
 
-
 ## Marketplace listing
 
 Get listings/releases from a user's inventory (this does not require authentication)
@@ -137,7 +133,7 @@ Get listings/releases from a user's inventory (this does not require authenticat
 >>> inventory.pages
 17
 >>> first_page = inventory.page(0)
->>> first_page[0] # get the first listing on the page
+>>> first_page[0]  # get the first listing on the page
 <Listing 2314412455 'Bing Crosby - Der Bingle (10")'>
 >>> first_listing.release
 <Release 2604203 'Der Bingle'>
@@ -162,14 +158,12 @@ _To learn how to update your inventory and delete listings, have a look at the
 <https://python3-discogs-client.readthedocs.org/en/latest/listing.html>) in our
 docs._
 
-
 ## For more information
 
 - Read through [python3-discogs-client.readthedocs.org](https://python3-discogs-client.readthedocs.org) for step by step instructions.
 - Check the [discogs_client Python package documentation](https://python3-discogs-client.readthedocs.org/en/latest/discogs_client.html) to find out details on specific modules, classes, methods, and more.
 - Or just spin up a REPL and use `dir()` on things :)
 - If you have questions or feature requests, please ask in the [discussion section](https://github.com/joalla/discogs_client/discussions).
-
 
 ## Contributing
 

--- a/README.mkd
+++ b/README.mkd
@@ -11,7 +11,7 @@ It also supports OAuth 1.0a authorization, which allows you to change user data
 such as profile information, collections and wantlists, inventory, and orders.
 
 Find usage information [on our documentation pages](
-https://python3-discogs-client.readthedocs.org),
+<https://python3-discogs-client.readthedocs.org>),
 ask for help, suggest features and help others in the [discussion section of our
 github repo](https://github.com/joalla/discogs_client/discussions). If you'd
 like to contribute your code, you are welcome to submit a pull-request as
@@ -22,8 +22,8 @@ Client"](https://www.discogs.com/forum/thread/822690) on the Discogs developer
 forum we use to announce releases and other news.
 
 [![Coverage Status](
-https://coveralls.io/repos/github/joalla/discogs_client/badge.svg)](
-https://coveralls.io/github/joalla/discogs_client)
+<https://coveralls.io/repos/github/joalla/discogs_client/badge.svg>)](
+<https://coveralls.io/github/joalla/discogs_client>)
 
 ## Installation
 
@@ -31,7 +31,7 @@ Install [the client from PyPI](https://pypi.org/project/python3-discogs-client/)
 using your favorite package manager.
 
 ```sh
-$ pip3 install python3-discogs-client
+pip3 install python3-discogs-client
 ```
 
 ## Quickstart
@@ -45,7 +45,7 @@ $ pip3 install python3-discogs-client
 
 _For more information, have a look at the
 [quickstart section](
-https://python3-discogs-client.readthedocs.org/en/latest/quickstart.html)
+<https://python3-discogs-client.readthedocs.org/en/latest/quickstart.html>)
 in our documentation pages._
 
 
@@ -54,9 +54,9 @@ in our documentation pages._
 There are two different authorization methods you can choose from depending on
 your requirements:
 [User-token](
-https://python3-discogs-client.readthedocs.org/en/latest/authentication.html#user-token-authorization)
+<https://python3-discogs-client.readthedocs.org/en/latest/authentication.html#user-token-authorization>)
 and [OAuth](
-https://python3-discogs-client.readthedocs.org/en/latest/authentication.html#oauth-authorization)
+<https://python3-discogs-client.readthedocs.org/en/latest/authentication.html#oauth-authorization>)
 authentication.
 
 _Note that Authorization is an optional feature of the Discogs API but a lot of
@@ -71,7 +71,7 @@ requiring authentication, such as search (see below).
 
 For this, you'll need to
 [generate a user-token from your developer settings](
-https://python3-discogs-client.readthedocs.org/en/latest/authentication.html#user-token-authentication)
+<https://python3-discogs-client.readthedocs.org/en/latest/authentication.html#user-token-authentication>)
 on the Discogs website.
 
 ```python
@@ -116,13 +116,32 @@ You can drill down as far as you like.
 
 _Have a look at the
 [searching](
-https://python3-discogs-client.readthedocs.org/en/latest/quickstart.html#searching)
+<https://python3-discogs-client.readthedocs.org/en/latest/quickstart.html#searching>)
 and [fetching data](
-https://python3-discogs-client.readthedocs.org/en/latest/fetching_data.html)
+<https://python3-discogs-client.readthedocs.org/en/latest/fetching_data.html>)
 sections in our documentation pages._
 
 
 ## Marketplace listing
+
+Getting listings/releases from a user's inventory (this does not require authentication)
+
+```python
+>>> user = d.user('username')
+>>> inventory = user.inventory
+>>> inventory.count
+1671
+>>> inventory.pages
+34
+>>> inventory.per_page = 100
+>>> inventory.pages
+17
+>>> first_page = inventory.page(0)
+>>> first_page[0] # get the first listing on the page
+<Listing 2314412455 'Bing Crosby - Der Bingle (10")'>
+>>> first_listing.release
+<Release 2604203 'Der Bingle'>
+```
 
 As an authenticated user you can add, edit and delete your own marketplace listings.
 
@@ -140,7 +159,7 @@ me.inventory.add_listing(
 
 _To learn how to update your inventory and delete listings, have a look at the
 [marketplace listing section](
-https://python3-discogs-client.readthedocs.org/en/latest/listing.html) in our
+<https://python3-discogs-client.readthedocs.org/en/latest/listing.html>) in our
 docs._
 
 

--- a/docs/source/listing.md
+++ b/docs/source/listing.md
@@ -24,16 +24,16 @@ See the module documentation for possible values of condition
 {class}`discogs_client.utils.Condition` and status
 {class}`discogs_client.utils.Status`.
 
-
 ## Read
 
 You do not have to be authenticated to read a user's public inventory.
 
 ```python
-user = d.user('username')       # gets a user with username
-inventory = user.inventory      # get that user's inventory
-first_page = inventory.page(0)  # get the first page
-first_listing = first_page[0]   # get the first listing from that page
+user = d.user('username')         # gets a user with username
+inventory = user.inventory        # get that user's inventory
+first_page = inventory.page(0)    # get the first page
+first_listing = first_page[0]     # get the first listing from that page
+release = first_listing.release   # get the release from the release
 ````
 
 ## Update

--- a/docs/source/listing.md
+++ b/docs/source/listing.md
@@ -25,6 +25,17 @@ See the module documentation for possible values of condition
 {class}`discogs_client.utils.Status`.
 
 
+## Read
+
+You do not have to be authenticated to read a user's public inventory.
+
+```python
+user = d.user('username')       # gets a user with username
+inventory = user.inventory      # get that user's inventory
+first_page = inventory.page(0)  # get the first page
+first_listing = first_page[0]   # get the first listing from that page
+````
+
 ## Update
 
 Get the most expensive listing and update its price.


### PR DESCRIPTION
## Problem

In regards to **Marketplace Listings** - there are examples for Create, Update and Delete but not Read.

I will admit that this is something that confused me at first, so I wanted to add examples for others who maybe trying to do the same.

## Pull Request

Pull request to update the README and docs with examples of how you can read and get listings from a user's inventory without authenticating as said user.

