### PR TITLE
Fix readthedocs builds, update copyright year & Writing Docs page

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,16 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+sphinx:
+  configuration: docs/source/conf.py
+
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,7 +18,7 @@ sys.path.insert(0, os.path.abspath('../../discogs_client/'))
 # -- Project information -----------------------------------------------------
 
 project = 'python3-discogs-client'
-copyright = '2020-2022, The Joalla Team'
+copyright = '2020-2024, The Joalla Team'
 author = 'The Joalla Team'
 
 # The full version, including alpha/beta/rc tags

--- a/docs/source/writing_docs.md
+++ b/docs/source/writing_docs.md
@@ -12,16 +12,10 @@ git clone <git url>
 
 ## Install Prerequisites
 
-Install Sphinx
+Being located in the root of the repo, install Sphinx and its requirements.
 
 ```
-pip install -r sphinx_requirements.txt
-```
-
-Install python3-discogs-client itself into your (virtual) development environment. This is required by Sphinx autodoc:
-
-```
-python setup.py develop
+pip install -e '.[docs]'
 ```
 
 ## Edit Files
@@ -38,9 +32,9 @@ Almost all documentation is written using the Markdown format.  The exception is
 
 ## Build the Documentation
 
-After your changes are complete, you can build the documentation by running the ```make html``` command.  This will build the documentation in the ```docs/build/html``` directory.  
+To build the documenation on your local machine change into the ```docs/``` directory and run ```make html```.  Find the output in the ```docs/build/html``` directory.
 
-Please note that as of this writing, Python 3.10 will not work.  Please use Python Python >=3.6 and <=3.9 when building the documentation.
+We reommend using Python 3.9 or Python 3.11 for building the documentation.
 
 Check the command line input to make sure no errors occurred.  If there is an error, fix it, and re-run the command. You can ignore warnings similar to this one:
 

--- a/docs/source/writing_docs.md
+++ b/docs/source/writing_docs.md
@@ -34,7 +34,7 @@ Almost all documentation is written using the Markdown format.  The exception is
 
 To build the documenation on your local machine change into the ```docs/``` directory and run ```make html```.  Find the output in the ```docs/build/html``` directory.
 
-We reommend using Python 3.9 or Python 3.11 for building the documentation.
+We recommend using Python 3.9 or Python 3.11 for building the documentation.
 
 Check the command line input to make sure no errors occurred.  If there is an error, fix it, and re-run the command. You can ignore warnings similar to this one:
 

--- a/setup.py
+++ b/setup.py
@@ -29,4 +29,11 @@ setup(
         packages=[
             'discogs_client',
             ],
-        )
+       extras_require={
+           "docs": [
+               "sphinx",
+               "sphinx-rtd-theme",
+               "myst-parser",
+           ],
+       }
+)

--- a/sphinx_requirements.txt
+++ b/sphinx_requirements.txt
@@ -1,4 +1,0 @@
-Jinja2<3.1
-Sphinx!=5.2.0.post0
-sphinx-rtd-theme
-myst-parser


### PR DESCRIPTION
Fixes #136 

Add .readthedocs.yaml to fix rtd-builds and add docs requirements (replacing sphinx_requirements.txt) via extras section in setup.py.

This ignores our Jinja2 version fixation! Let's see if that works!

Also some wording changes in our "Writing docs section".

In enabled this PR's branch to review the changes and the succesful build: https://python3-discogs-client.readthedocs.io/en/fix_readthedocs/writing_docs.html

Build on RTD seems to be fine. Sphinx autodoc worked as well (that was IIRC the reason we had Jinja2 fixated to a specific version in the now deleted sphinx_requirements.txt.)