### PR TITLE
Bump ubuntu version in build workflow

### DIFF
--- a/.github/workflows/discogs_client-build.yml
+++ b/.github/workflows/discogs_client-build.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']

--- a/.github/workflows/discogs_client-build.yml
+++ b/.github/workflows/discogs_client-build.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']


### PR DESCRIPTION
ubuntu-20.04 is being deprecated and will be unsupported by 2025-04-01

https://github.com/actions/runner-images/issues/11101