### PR TITLE
Fix/getitem pagination walk

### DIFF
--- a/discogs_client/client.py
+++ b/discogs_client/client.py
@@ -19,6 +19,7 @@ class Client:
         self.user_agent = user_agent
         self.verbose = False
         self._fetcher = RequestsFetcher()
+        self._trust_per_page = True  # Default: True
 
         if consumer_key and consumer_secret:
             self.set_consumer_key(consumer_key, consumer_secret)
@@ -219,3 +220,13 @@ class Client:
         """
         self._fetcher.connect_timeout = connect
         self._fetcher.read_timeout = read
+
+    @property
+    def trust_per_page(self) -> bool:
+        return self._trust_per_page
+
+    @trust_per_page.setter
+    def trust_per_page(self, value: bool) -> None:
+        if not isinstance(value, bool):
+            raise ValueError("trust_per_page must be a bool")
+        self._trust_per_page = value

--- a/discogs_client/models.py
+++ b/discogs_client/models.py
@@ -354,18 +354,26 @@ class BasePaginatedResponse:
         return item
 
     def __getitem__(self, index):
-        page_index = index // self.per_page + 1
-        offset = index % self.per_page
-
-        try:
-            page = self.page(page_index)
-        except HTTPError as e:
-            if e.status_code == 404:
-                raise IndexError(e.msg)
-            else:
-                raise
-
-        return page[offset]
+    # Rather than trusting per_page metadata for offset math, we walk
+    # through actual page sizes sequentially. This handles cases where
+    # Discogs returns fewer items than per_page claims, which causes
+    # index-out-of-range errors when using the standard calculation:
+    # page_index = index // self.per_page + 1
+    # offset = index % self.per_page
+        current = 0
+        page_index = 1
+        while True:
+            try:
+                page = self.page(page_index)
+            except HTTPError as e:
+                if e.status_code == 404:
+                    raise IndexError(e.msg)
+                else:
+                    raise
+            if current + len(page) > index:
+                return page[index - current]
+            current += len(page)
+            page_index += 1
 
     def __len__(self):
         return self.count

--- a/discogs_client/models.py
+++ b/discogs_client/models.py
@@ -354,15 +354,12 @@ class BasePaginatedResponse:
         return item
 
     def __getitem__(self, index):
-    # Rather than trusting per_page metadata for offset math, we walk
-    # through actual page sizes sequentially. This handles cases where
-    # Discogs returns fewer items than per_page claims, which causes
-    # index-out-of-range errors when using the standard calculation:
-    # page_index = index // self.per_page + 1
-    # offset = index % self.per_page
-        current = 0
-        page_index = 1
-        while True:
+        if self.client._trust_per_page:
+            # Directly jump to index using offset math.
+            # Default
+            page_index = index // self.per_page + 1
+            offset = index % self.per_page
+
             try:
                 page = self.page(page_index)
             except HTTPError as e:
@@ -370,10 +367,27 @@ class BasePaginatedResponse:
                     raise IndexError(e.msg)
                 else:
                     raise
-            if current + len(page) > index:
-                return page[index - current]
-            current += len(page)
-            page_index += 1
+
+            return page[offset]
+
+        else:
+            # Sequentially walks through each page until index or end of array reached.
+            # Opt-in
+            current = 0
+            page_index = 1
+            while True:
+                try:
+                    page = self.page(page_index)
+                except HTTPError as e:
+                    if e.status_code == 404:
+                        raise IndexError(e.msg)
+                    else:
+                        raise
+                if current + len(page) > index:
+                    return page[index - current]
+                current += len(page)
+                page_index += 1
+
 
     def __len__(self):
         return self.count

--- a/discogs_client/models.py
+++ b/discogs_client/models.py
@@ -354,9 +354,15 @@ class BasePaginatedResponse:
         return item
 
     def __getitem__(self, index):
+        """Retrieve an item by its index.
+
+        By default, uses the API's ``per_page`` value to calculate the page
+        containing the item directly. If the API returns fewer items per page
+        than reported, this may yield incorrect results — set
+        ``client.trust_per_page = False`` to fall back to a sequential page
+        walk at the cost of performance.
+        """
         if self.client._trust_per_page:
-            # Directly jump to index using offset math.
-            # Default
             page_index = index // self.per_page + 1
             offset = index % self.per_page
 
@@ -364,29 +370,25 @@ class BasePaginatedResponse:
                 page = self.page(page_index)
             except HTTPError as e:
                 if e.status_code == 404:
-                    raise IndexError(e.msg)
-                else:
-                    raise
+                    raise IndexError(e.msg) from e
+                raise
 
             return page[offset]
 
-        else:
-            # Sequentially walks through each page until index or end of array reached.
-            # Opt-in
-            current = 0
-            page_index = 1
-            while True:
-                try:
-                    page = self.page(page_index)
-                except HTTPError as e:
-                    if e.status_code == 404:
-                        raise IndexError(e.msg)
-                    else:
-                        raise
-                if current + len(page) > index:
-                    return page[index - current]
-                current += len(page)
-                page_index += 1
+        # Fallback to sequential page loading if we're not trusting the per_page parameter
+        current = 0
+        page_index = 1
+        while True:
+            try:
+                page = self.page(page_index)
+            except HTTPError as e:
+                if e.status_code == 404:
+                    raise IndexError(e.msg) from e
+                raise
+            if current + len(page) > index:
+                return page[index - current]
+            current += len(page)
+            page_index += 1
 
 
     def __len__(self):

--- a/discogs_client/tests/test_core.py
+++ b/discogs_client/tests/test_core.py
@@ -114,6 +114,7 @@ class CoreTestCase(DiscogsClientTestCase):
     def test_pagination_index_without_trust_per_page_and_short_pages(self):
         """Without trust_per_page, sequential page walking handles under-filled pages correctly."""
         client = Client('ua')
+        client.trust_per_page = False  # opt into sequential walk
         client._base_url = ''
         client._trust_per_page = False
         client._fetcher = MemoryFetcher({

--- a/discogs_client/tests/test_core.py
+++ b/discogs_client/tests/test_core.py
@@ -111,6 +111,157 @@ class CoreTestCase(DiscogsClientTestCase):
         results.per_page = 10
         self.assertTrue(results._num_pages is None)
 
+    def test_pagination_with_short_page(self):
+        """Indexing walks actual page sizes when the API under-fills a page."""
+        client = Client('ua')
+        client._base_url = ''
+        client._fetcher = MemoryFetcher({
+            '/artists/1': (
+                b'{"id": 1, "name": "Badger", "releases_url": "/artists/1/releases"}',
+                200,
+            ),
+            '/artists/1/releases?page=1&per_page=50': (
+                b'{"pagination": {"per_page": 50, "pages": 2, "items": 2}, '
+                b'"releases": [{"id": 101, "type": "release", "title": "First"}]}',
+                200,
+            ),
+            '/artists/1/releases?page=2&per_page=50': (
+                b'{"pagination": {"per_page": 50, "pages": 2, "items": 2}, '
+                b'"releases": [{"id": 102, "type": "release", "title": "Second"}]}',
+                200,
+            ),
+        })
+
+        results = client.artist(1).releases
+
+        self.assertEqual(results.pages, 2)
+        self.assertEqual(len(results.page(1)), 1)
+        self.assertEqual(results[0].id, 101)
+        self.assertEqual(results[1].id, 102)
+        self.assertRaises(IndexError, lambda: results[2])
+
+    def test_pagination_with_varying_page_sizes(self):
+        """Indexing works correctly with pages of different actual sizes."""
+        client = Client('ua')
+        client._base_url = ''
+        client._fetcher = MemoryFetcher({
+            '/artists/1': (
+                b'{"id": 1, "name": "Badger", "releases_url": "/artists/1/releases"}',
+                200,
+            ),
+            '/artists/1/releases?page=1&per_page=50': (
+                b'{"pagination": {"per_page": 50, "pages": 3, "items": 8}, '
+                b'"releases": ['
+                b'{"id": 101, "type": "release", "title": "First"},'
+                b'{"id": 102, "type": "release", "title": "Second"},'
+                b'{"id": 103, "type": "release", "title": "Third"}'
+                b']}',
+                200,
+            ),
+            '/artists/1/releases?page=2&per_page=50': (
+                b'{"pagination": {"per_page": 50, "pages": 3, "items": 8}, '
+                b'"releases": ['
+                b'{"id": 104, "type": "release", "title": "Fourth"},'
+                b'{"id": 105, "type": "release", "title": "Fifth"}'
+                b']}',
+                200,
+            ),
+            '/artists/1/releases?page=3&per_page=50': (
+                b'{"pagination": {"per_page": 50, "pages": 3, "items": 8}, '
+                b'"releases": ['
+                b'{"id": 106, "type": "release", "title": "Sixth"},'
+                b'{"id": 107, "type": "release", "title": "Seventh"},'
+                b'{"id": 108, "type": "release", "title": "Eighth"}'
+                b']}',
+                200,
+            ),
+        })
+
+        results = client.artist(1).releases
+
+        # Verify we can access items across all pages
+        self.assertEqual(results[0].id, 101)
+        self.assertEqual(results[1].id, 102)
+        self.assertEqual(results[2].id, 103)
+        self.assertEqual(results[3].id, 104)  # First item on page 2
+        self.assertEqual(results[4].id, 105)  # Last item on page 2
+        self.assertEqual(results[5].id, 106)  # First item on page 3
+        self.assertEqual(results[7].id, 108)  # Last item
+
+        # Verify out-of-bounds access raises IndexError
+        self.assertRaises(IndexError, lambda: results[8])
+
+    def test_pagination_with_short_page_sequential_traversal(self):
+        """Verify sequential page walking works when all pages are short."""
+        client = Client('ua')
+        client._base_url = ''
+        client._fetcher = MemoryFetcher({
+            '/artists/1': (
+                b'{"id": 1, "name": "Badger", "releases_url": "/artists/1/releases"}',
+                200,
+            ),
+            '/artists/1/releases?page=1&per_page=50': (
+                b'{"pagination": {"per_page": 50, "pages": 4, "items": 4}, '
+                b'"releases": [{"id": 201, "type": "release", "title": "A"}]}',
+                200,
+            ),
+            '/artists/1/releases?page=2&per_page=50': (
+                b'{"pagination": {"per_page": 50, "pages": 4, "items": 4}, '
+                b'"releases": [{"id": 202, "type": "release", "title": "B"}]}',
+                200,
+            ),
+            '/artists/1/releases?page=3&per_page=50': (
+                b'{"pagination": {"per_page": 50, "pages": 4, "items": 4}, '
+                b'"releases": [{"id": 203, "type": "release", "title": "C"}]}',
+                200,
+            ),
+            '/artists/1/releases?page=4&per_page=50': (
+                b'{"pagination": {"per_page": 50, "pages": 4, "items": 4}, '
+                b'"releases": [{"id": 204, "type": "release", "title": "D"}]}',
+                200,
+            ),
+        })
+
+        results = client.artist(1).releases
+
+        # With per_page=50 but only 1 item per actual page,
+        # math-based indexing would fail. Sequential walking should work.
+        self.assertEqual(results[0].id, 201)
+        self.assertEqual(results[1].id, 202)
+        self.assertEqual(results[2].id, 203)
+        self.assertEqual(results[3].id, 204)
+        self.assertRaises(IndexError, lambda: results[4])
+
+    def test_pagination_404_exception_chaining(self):
+        """Verify that HTTPError 404 is properly chained when index is out of bounds."""
+        client = Client('ua')
+        client._base_url = ''
+        client._fetcher = MemoryFetcher({
+            '/artists/1': (
+                b'{"id": 1, "name": "Badger", "releases_url": "/artists/1/releases"}',
+                200,
+            ),
+            '/artists/1/releases?page=1&per_page=50': (
+                b'{"pagination": {"per_page": 50, "pages": 1, "items": 2}, '
+                b'"releases": ['
+                b'{"id": 301, "type": "release", "title": "Only"},'
+                b'{"id": 302, "type": "release", "title": "Two"}'
+                b']}',
+                200,
+            ),
+        })
+
+        results = client.artist(1).releases
+
+        # Access valid items
+        self.assertEqual(results[0].id, 301)
+        self.assertEqual(results[1].id, 302)
+
+        # Accessing beyond bounds should raise IndexError
+        # (which is chained from HTTPError 404)
+        with self.assertRaises(IndexError):
+            results[100]
+
     def test_timeout_defaults_to_none(self):
         # Need to create client without LoggingDelegator here
         # self.d would throw AttributeError trying to access timeout properties on LoggingDelegator

--- a/discogs_client/tests/test_core.py
+++ b/discogs_client/tests/test_core.py
@@ -111,156 +111,44 @@ class CoreTestCase(DiscogsClientTestCase):
         results.per_page = 10
         self.assertTrue(results._num_pages is None)
 
-    def test_pagination_with_short_page(self):
-        """Indexing walks actual page sizes when the API under-fills a page."""
+    def test_pagination_index_without_trust_per_page_and_short_pages(self):
+        """Without trust_per_page, sequential page walking handles under-filled pages correctly."""
         client = Client('ua')
         client._base_url = ''
+        client._trust_per_page = False
         client._fetcher = MemoryFetcher({
             '/artists/1': (
                 b'{"id": 1, "name": "Badger", "releases_url": "/artists/1/releases"}',
                 200,
             ),
             '/artists/1/releases?page=1&per_page=50': (
-                b'{"pagination": {"per_page": 50, "pages": 2, "items": 2}, '
-                b'"releases": [{"id": 101, "type": "release", "title": "First"}]}',
-                200,
-            ),
-            '/artists/1/releases?page=2&per_page=50': (
-                b'{"pagination": {"per_page": 50, "pages": 2, "items": 2}, '
-                b'"releases": [{"id": 102, "type": "release", "title": "Second"}]}',
-                200,
-            ),
-        })
-
-        results = client.artist(1).releases
-
-        self.assertEqual(results.pages, 2)
-        self.assertEqual(len(results.page(1)), 1)
-        self.assertEqual(results[0].id, 101)
-        self.assertEqual(results[1].id, 102)
-        self.assertRaises(IndexError, lambda: results[2])
-
-    def test_pagination_with_varying_page_sizes(self):
-        """Indexing works correctly with pages of different actual sizes."""
-        client = Client('ua')
-        client._base_url = ''
-        client._fetcher = MemoryFetcher({
-            '/artists/1': (
-                b'{"id": 1, "name": "Badger", "releases_url": "/artists/1/releases"}',
-                200,
-            ),
-            '/artists/1/releases?page=1&per_page=50': (
-                b'{"pagination": {"per_page": 50, "pages": 3, "items": 8}, '
+                b'{"pagination": {"per_page": 50, "pages": 3, "items": 5}, '
                 b'"releases": ['
-                b'{"id": 101, "type": "release", "title": "First"},'
-                b'{"id": 102, "type": "release", "title": "Second"},'
-                b'{"id": 103, "type": "release", "title": "Third"}'
+                b'{"id": 101, "type": "release", "title": "A"},'
+                b'{"id": 102, "type": "release", "title": "B"}'
                 b']}',
                 200,
             ),
             '/artists/1/releases?page=2&per_page=50': (
-                b'{"pagination": {"per_page": 50, "pages": 3, "items": 8}, '
-                b'"releases": ['
-                b'{"id": 104, "type": "release", "title": "Fourth"},'
-                b'{"id": 105, "type": "release", "title": "Fifth"}'
-                b']}',
+                b'{"pagination": {"per_page": 50, "pages": 3, "items": 5}, '
+                b'"releases": [{"id": 103, "type": "release", "title": "C"}]}',
                 200,
             ),
             '/artists/1/releases?page=3&per_page=50': (
-                b'{"pagination": {"per_page": 50, "pages": 3, "items": 8}, '
+                b'{"pagination": {"per_page": 50, "pages": 3, "items": 5}, '
                 b'"releases": ['
-                b'{"id": 106, "type": "release", "title": "Sixth"},'
-                b'{"id": 107, "type": "release", "title": "Seventh"},'
-                b'{"id": 108, "type": "release", "title": "Eighth"}'
+                b'{"id": 104, "type": "release", "title": "D"},'
+                b'{"id": 105, "type": "release", "title": "E"}'
                 b']}',
                 200,
             ),
         })
 
         results = client.artist(1).releases
-
-        # Verify we can access items across all pages
-        self.assertEqual(results[0].id, 101)
-        self.assertEqual(results[1].id, 102)
-        self.assertEqual(results[2].id, 103)
-        self.assertEqual(results[3].id, 104)  # First item on page 2
-        self.assertEqual(results[4].id, 105)  # Last item on page 2
-        self.assertEqual(results[5].id, 106)  # First item on page 3
-        self.assertEqual(results[7].id, 108)  # Last item
-
-        # Verify out-of-bounds access raises IndexError
-        self.assertRaises(IndexError, lambda: results[8])
-
-    def test_pagination_with_short_page_sequential_traversal(self):
-        """Verify sequential page walking works when all pages are short."""
-        client = Client('ua')
-        client._base_url = ''
-        client._fetcher = MemoryFetcher({
-            '/artists/1': (
-                b'{"id": 1, "name": "Badger", "releases_url": "/artists/1/releases"}',
-                200,
-            ),
-            '/artists/1/releases?page=1&per_page=50': (
-                b'{"pagination": {"per_page": 50, "pages": 4, "items": 4}, '
-                b'"releases": [{"id": 201, "type": "release", "title": "A"}]}',
-                200,
-            ),
-            '/artists/1/releases?page=2&per_page=50': (
-                b'{"pagination": {"per_page": 50, "pages": 4, "items": 4}, '
-                b'"releases": [{"id": 202, "type": "release", "title": "B"}]}',
-                200,
-            ),
-            '/artists/1/releases?page=3&per_page=50': (
-                b'{"pagination": {"per_page": 50, "pages": 4, "items": 4}, '
-                b'"releases": [{"id": 203, "type": "release", "title": "C"}]}',
-                200,
-            ),
-            '/artists/1/releases?page=4&per_page=50': (
-                b'{"pagination": {"per_page": 50, "pages": 4, "items": 4}, '
-                b'"releases": [{"id": 204, "type": "release", "title": "D"}]}',
-                200,
-            ),
-        })
-
-        results = client.artist(1).releases
-
-        # With per_page=50 but only 1 item per actual page,
-        # math-based indexing would fail. Sequential walking should work.
-        self.assertEqual(results[0].id, 201)
-        self.assertEqual(results[1].id, 202)
-        self.assertEqual(results[2].id, 203)
-        self.assertEqual(results[3].id, 204)
-        self.assertRaises(IndexError, lambda: results[4])
-
-    def test_pagination_404_exception_chaining(self):
-        """Verify that HTTPError 404 is properly chained when index is out of bounds."""
-        client = Client('ua')
-        client._base_url = ''
-        client._fetcher = MemoryFetcher({
-            '/artists/1': (
-                b'{"id": 1, "name": "Badger", "releases_url": "/artists/1/releases"}',
-                200,
-            ),
-            '/artists/1/releases?page=1&per_page=50': (
-                b'{"pagination": {"per_page": 50, "pages": 1, "items": 2}, '
-                b'"releases": ['
-                b'{"id": 301, "type": "release", "title": "Only"},'
-                b'{"id": 302, "type": "release", "title": "Two"}'
-                b']}',
-                200,
-            ),
-        })
-
-        results = client.artist(1).releases
-
-        # Access valid items
-        self.assertEqual(results[0].id, 301)
-        self.assertEqual(results[1].id, 302)
-
-        # Accessing beyond bounds should raise IndexError
-        # (which is chained from HTTPError 404)
-        with self.assertRaises(IndexError):
-            results[100]
+        self.assertEqual(results[0].id, 101)  # page 1
+        self.assertEqual(results[2].id, 103)  # page 2, cross-page
+        self.assertEqual(results[4].id, 105)  # page 3, last item
+        self.assertRaises(IndexError, lambda: results[5])
 
     def test_timeout_defaults_to_none(self):
         # Need to create client without LoggingDelegator here

--- a/docs/source/optional_configuration.md
+++ b/docs/source/optional_configuration.md
@@ -30,3 +30,25 @@ client.set_timeout(
 ```
 
 _Timeouts support integer and float values, you can also set either value to `None` to disable timeout for connect or read separately_
+
+## Trust Discogs per page value
+
+When accessing paginated results by index (e.g. `results[42]`),
+python3-discogs-client uses the `per_page` value from the API response to
+calculate which page contains the item directly. This is fast, but assumes the
+API always returns exactly `per_page` items per page.
+
+If the API returns fewer items per page than the reported `per_page` value,
+this calculation can be off. In such cases, disable this behaviour to fall
+back to a sequential page walk:
+
+```python
+>>> import discogs_client
+>>> d = discogs_client.Client('ExampleApplication/0.1')
+>>> d.trust_per_page = False
+```
+
+:::{attention}
+The sequential fallback is slower for large result sets, as it must fetch pages
+one by one until it reaches the requested index.
+:::


### PR DESCRIPTION
## Problem
Discogs sometimes returns fewer items per page than the `per_page` 
metadata claims. This causes `__getitem__` to calculate incorrect 
page indices and offsets, resulting in `IndexError: list index out 
of range` on indices near page boundaries.

Verified that page sizes vary and don't match metadata:
    print(len(results.page(1)))  # 47, not 50
    print(len(results.page(2)))  # 49, not 50

## Fix
Rather than trusting `per_page` metadata for offset math, walk 
through actual page sizes sequentially to find the correct page 
and offset.

## Tradeoff
Accessing a high index now requires fetching all preceding pages 
sequentially. Performance could be improved further by caching 
actual page sizes as they're fetched.

Closes #183 